### PR TITLE
Fix datasource properties comparison not right when properties are map type

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/datasource/pool/creator/DataSourceReflection.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/datasource/pool/creator/DataSourceReflection.java
@@ -90,12 +90,16 @@ public final class DataSourceReflection {
             String fieldName = getGetterFieldName(each, prefix);
             if (GENERAL_CLASS_TYPES.contains(each.getReturnType()) && !SKIPPED_PROPERTY_KEYS.contains(fieldName)) {
                 Object fieldValue = each.invoke(dataSource);
-                if (null != fieldValue) {
+                if (null != fieldValue && isEmptyProperties(fieldValue)) {
                     result.put(fieldName, fieldValue);
                 }
             }
         }
         return result;
+    }
+    
+    private boolean isEmptyProperties(final Object fieldValue) {
+        return !(fieldValue instanceof Properties) || !((Properties) fieldValue).isEmpty();
     }
     
     private Collection<Method> findAllGetterMethods(final String methodPrefix) {

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/datasource/props/DataSourceProperties.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/datasource/props/DataSourceProperties.java
@@ -104,6 +104,9 @@ public final class DataSourceProperties {
             if (!dataSourceProps.getAllLocalProperties().containsKey(entry.getKey())) {
                 continue;
             }
+            if (entry.getValue() instanceof Map) {
+                return entry.getValue().equals(dataSourceProps.getAllLocalProperties().get(entry.getKey()));
+            }
             if (!String.valueOf(entry.getValue()).equals(String.valueOf(dataSourceProps.getAllLocalProperties().get(entry.getKey())))) {
                 return false;
             }

--- a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/api/yaml/YamlShardingSphereDataSourceFactory.java
+++ b/jdbc/core/src/main/java/org/apache/shardingsphere/driver/api/yaml/YamlShardingSphereDataSourceFactory.java
@@ -130,6 +130,9 @@ public final class YamlShardingSphereDataSourceFactory {
     private static DataSource createDataSource(final Map<String, DataSource> dataSourceMap, final YamlRootConfiguration rootConfig) throws SQLException {
         ModeConfiguration modeConfig = null == rootConfig.getMode() ? null : new YamlModeConfigurationSwapper().swapToObject(rootConfig.getMode());
         Collection<RuleConfiguration> ruleConfigs = SWAPPER_ENGINE.swapToRuleConfigurations(rootConfig.getRules());
+        if (dataSourceMap.isEmpty() && ruleConfigs.isEmpty()) {
+            return ShardingSphereDataSourceFactory.createDataSource(rootConfig.getDatabaseName(), modeConfig);
+        }
         return ShardingSphereDataSourceFactory.createDataSource(rootConfig.getDatabaseName(), modeConfig, dataSourceMap, ruleConfigs, rootConfig.getProps());
     }
     


### PR DESCRIPTION
1. Fix datasource properties comparison not right when properties are map type.
2. Fix start up NPE when use `ShardingSphereDriver` with cluster mode.